### PR TITLE
Add support for custom inventory provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ provider = Inventory("steamsupply", "9st947vs0qmgfpeqde1gj92l0oqmhysm")
 # using steam as inventory provider
 provider = Inventory() # or Inventory("steamcommunity")
 
+# using a custom api as inventory provider
+# requests will be sent to {url}/inventory/{steam_id}/{app_id}/{context_id}?api_key=apikey
+provider = Inventory("http://localhost:8000", "9st947vs0qmgfpeqde1gj92l0oqmhysm")
+
 # get an inventory
 inventory = provider.fetch("76561198253325712")
 ```

--- a/src/tf2_utils/inventory.py
+++ b/src/tf2_utils/inventory.py
@@ -1,6 +1,7 @@
 from .providers.steamcommunity import SteamCommunity
 from .providers.steamsupply import SteamSupply
 from .providers.steamapis import SteamApis
+from .providers.custom import Custom
 from .sku import get_sku
 
 import requests
@@ -43,6 +44,11 @@ class Inventory:
 
         if provider_name == "steamcommunity":
             # already set
+            return
+
+        # if provider_name is a url, assign it as a custom provider address
+        if provider_name.lower().startswith("http"):
+            self.provider = Custom(api_key, provider_name.lower())
             return
 
         # loop through providers create object

--- a/src/tf2_utils/providers/custom.py
+++ b/src/tf2_utils/providers/custom.py
@@ -1,0 +1,12 @@
+class Custom:
+    def __init__(self, api_key: str, url: str) -> None:
+        self.api_key = api_key
+        self.url = url.rstrip('/')
+
+    def get_url_and_params(
+        self, steam_id: str, app_id: int, context_id: int
+    ) -> tuple[str, dict]:
+        return (
+            f"{self.url}/inventory/{steam_id}/{app_id}/{context_id}",
+            {"api_key": self.api_key},
+        )


### PR DESCRIPTION
Option to Input a URL to set it as an inventory provider. Suitable for people using request rotators or similar to make requests to Steam.